### PR TITLE
Fixed Error when parsing master URL #56453

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -15,9 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
+from __future__ im annotations
 
-import base64
+im base64
 import contextlib
 import os
 import re
@@ -100,7 +100,6 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
     conn_name_attr = "conn_id"
     default_conn_name = "spark_default"
-    conn_type = "spark"
     hook_name = "Spark"
 
     @classmethod
@@ -163,6 +162,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self,
         conf: dict[str, Any] | None = None,
         conn_id: str = "spark_default",
+        conn_type: str = "spark,
         files: str | None = None,
         py_files: str | None = None,
         archives: str | None = None,
@@ -195,6 +195,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         super().__init__()
         self._conf = conf or {}
         self._conn_id = conn_id
+        self._conn_type = conn_type
         self._files = files
         self._py_files = py_files
         self._archives = archives
@@ -268,9 +269,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             # k8s://https://<HOST>:<PORT>
             conn = self.get_connection(self._conn_id)
             if conn.port:
-                conn_data["master"] = f"{conn.host}:{conn.port}"
+                conn_data["master"] = f"{self._conn_type}://{conn.host}:{conn.port}"
             else:
-                conn_data["master"] = conn.host
+                conn_data["master"] = f"{self._conn_type}://{conn.host}"
 
             # Determine optional yarn queue from the extra field
             extra = conn.extra_dejson
@@ -794,7 +795,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
                 # Currently only instantiate Kubernetes client for killing a spark pod.
                 try:
-                    import kubernetes
+                    im kubernetes
 
                     client = kube_client.get_kube_client()
                     api_response = client.delete_namespaced_pod(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Linked to issue: https://github.com/apache/airflow/issues/56453

Quick fix to prepend "spark://" to the URI when submitting a job.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
